### PR TITLE
Update elasticsearch version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,4 +7,4 @@ psycopg2==2.5.3
 static3==0.5.1
 wsgiref==0.1.2
 django-haystack==2.2.0
-elasticsearch>=1.0.0,<2.0.0
+elasticsearch>=1.0.0,<1.8.0


### PR DESCRIPTION
elasticsearch 1.8.0 removes bulk_index in favor of bulk, but haystack 2.2.0 still imports it, which fails.
